### PR TITLE
Master

### DIFF
--- a/appium/sample-scripts/python/device_finder.py
+++ b/appium/sample-scripts/python/device_finder.py
@@ -109,7 +109,7 @@ class DeviceFinder:
             if device['creditsPrice'] == 0 and device['locked'] == False and device['osType'] == "ANDROID" and device['softwareVersion']['apiLevel'] > 16:
                 print "Found device '%s'" % device['displayName']
                 print ""
-                return device['displayName']
+                return str(device['displayName'])
 
         print "No available device found"
         print ""
@@ -124,7 +124,7 @@ class DeviceFinder:
             if device['creditsPrice'] == 0 and device['locked'] == False and device['osType'] == "IOS":
                 print "Found device '%s'" % device['displayName']
                 print ""
-                return device['displayName']
+                return str(device['displayName'])
 
         print "No available device found"
         print ""


### PR DESCRIPTION
device_finder.py returns the device name currently as unicode, and
sometimes it causes the value to have extra u symbol in front of the
name: u'value'. This causes problems when adding the value to desired
capabilities as is.