### PR TITLE
scripts updated to using apiKey 

### DIFF
--- a/appium/sample-scripts/python/README.md
+++ b/appium/sample-scripts/python/README.md
@@ -16,18 +16,18 @@ online](http://appium.io/slate/en/master/?python#about-appium).
 
 Before testing can start you need to upload you mobile application to
 the cloud. To do so open and configure the upload.py script. You will
-need to configure your username (email) and password that you registered
-with to Testdroid cloud. Also you need to set the full path to your
+need to add your apiKey value that you can get from under "My Account"
+from Testdroid cloud. Also you'll need to set the full path to your
 mobile app. This can be an Android or iOS application.
 
 ```sh
-$ python update.py 
-{"status":0,"sessionId":"f4660af0-10f3-46e9-932b-0622f497b0d2","value":{"message":"uploads successful","uploadCount":1,"rejectCount":0,"expiresIn":1800,"uploads":{"file":"f4660af0-10f3-46e9-932b0622f497b0d2/Testdroid.apk"},"rejects":{}}}
+$ python upload.py 
+Filename to use in testdroid capabilities in your test: 719f52c4-2c34-4c25-b90b-08884f049d3a/Testdroid.apk
 ```
 
 From the response message you need to store the application's file
 name in the cloud. In this example upload it is
-'f4660af0-10f3-46e9-932b-0622f497b0d2/Testdroid.apk'.
+'719f52c4-2c34-4c25-b90b-08884f049d3a/Testdroid.apk'.
 
 ## Common Settings
 
@@ -61,8 +61,9 @@ Here are all the values that you need to edit:
 
 * *testdroid_app* - should be the name of the app you uploaded to
   cloud. Eg. if you uploaded your app using the upload.py script this
-  would look like
-  'f4660af0-10f3-46e9-932b-0622f497b0d2/Testdroid.apk'
+  would look like 'f4660af0-10f3-46e9-932b-0622f497b0d2/Testdroid.apk'
+  You can also use the value *latest* if you want to rerun a test
+  against your last uploaded app.
 
 
 ## Native iOS Specific Settings

--- a/appium/sample-scripts/python/device_finder.py
+++ b/appium/sample-scripts/python/device_finder.py
@@ -1,104 +1,42 @@
 # -*- coding: utf-8 -*-
 
-import os, sys, requests, json, time, httplib
-from optparse import OptionParser
-from urlparse import urljoin
-from datetime import datetime
+import requests, sys
 
 class DeviceFinder:
     # Cloud URL (not including API path)
     url = None
-    # Oauth access token
-    access_token = None
-    # Oauth refresh token
-    refresh_token = None
-    # Unix timestamp (seconds) when token expires
-    token_expiration_time = None
 
     """ Full constructor with username and password
     """
-    def __init__(self, username=None, password=None, url="https://cloud.testdroid.com", download_buffer_size=65536):
-        self.username = username
-        self.password = password
+    def __init__(self, url="https://cloud.testdroid.com", download_buffer_size=65536):
         self.cloud_url = url
         self.download_buffer_size = download_buffer_size
-
-    """ Get Oauth2 token
+       
+    """ Append dictionary items to header 
     """
-    def get_token(self):
-        if not self.access_token:
-            # TODO: refresh
-            url = "%s/oauth/token" % self.cloud_url
-            payload = {
-                "client_id": "testdroid-cloud-api",
-                "grant_type": "password",
-                "username": self.username,
-                "password": self.password
-            }
-            res = requests.post(
-                                url,
-                                data = payload,
-                                headers = { "Accept": "application/json" }
-                                )
-            if res.status_code != 200:
-                print "FAILED: Authentication or connection failure. Check Testdroid Cloud URL and your credentials."
-                sys.exit(-1)
-
-            reply = res.json()
-
-            self.access_token = reply['access_token']
-            self.refresh_token = reply['refresh_token']
-            self.token_expiration_time = time.time() + reply['expires_in']
-        elif self.token_expiration_time < time.time():
-            url = "%s/oauth/token" % self.cloud_url
-            payload = {
-                "client_id": "testdroid-cloud-api",
-                "grant_type": "refresh_token",
-                "refresh_token": self.refresh_token
-            }
-            res = requests.post(
-                                url,
-                                data = payload,
-                                headers = { "Accept": "application/json" }
-                                )
-            if res.status_code != 200:
-                print "FAILED: Unable to get a new access token using refresh token"
-                self.access_token = None
-                return self.get_token()
-
-            reply = res.json()
-
-            self.access_token = reply['access_token']
-            self.refresh_token = reply['refresh_token']
-            self.token_expiration_time = time.time() + reply['expires_in']
-
-        return self.access_token
-
-    """ Helper method for getting necessary headers to use for API calls, including authentication
-    """
-    def _build_headers(self):
-        return { "Authorization": "Bearer %s" % self.get_token(), "Accept": "application/json" }
-
-
-    """ GET from API resource
-    """
-    def get(self, path=None, payload={}, headers={}):
-        if path.find('v2/') >= 0:
-            cut_path = path.split('v2/')
-            path = cut_path[1]
-
-        url = "%s/api/v2/%s" % (self.cloud_url, path)
-        headers = dict(self._build_headers().items() + headers.items())
-        res =  requests.get(url, params=payload, headers=headers)
-        if headers['Accept'] == 'application/json':
-            return res.json()
-        else:
-            return res.text
-
+    def _build_headers(self, headers=None):
+        hdrs = {}
+        hdrs["Accept"] = "application/json"
+        if headers != None:
+            hdrs.update(headers)
+        return hdrs
+    
     """ Returns list of devices
     """
     def get_devices(self, limit=0):
         return self.get("devices?limit=%s" % (limit))
+        
+    """ GET from API resource
+    """
+    def get(self, path=None, get_headers=None):
+        url = "%s/api/v2/%s" % (self.cloud_url, path)
+        headers=self._build_headers(get_headers)
+        res =  requests.get(url, headers=self._build_headers(get_headers))
+        if res.ok:
+            return res.json()
+        else:
+            print "Could not retrieve free devices."
+            sys.exit -1
 
     """ Find available free Android device
     """
@@ -132,10 +70,10 @@ class DeviceFinder:
     """ Find out the API level of a Device
     """
     def device_API_level(self, deviceName):
-        print "Searching for API level of device %s" % deviceName
+        print "Searching for API level of device '%s'" % deviceName
 
         try:
-            device = self.get("devices", {'search' : deviceName})
+            device = self.get(path="devices", get_headers={'search':deviceName})
             apiLevel = device['data'][0]['softwareVersion']['apiLevel']
             print "Found API level: %s" % apiLevel
             return apiLevel

--- a/appium/sample-scripts/python/testdroid_android.py
+++ b/appium/sample-scripts/python/testdroid_android.py
@@ -4,7 +4,6 @@
 ##
 
 import os
-import sys
 import time
 import unittest
 from time import sleep

--- a/appium/sample-scripts/python/testdroid_android.py
+++ b/appium/sample-scripts/python/testdroid_android.py
@@ -25,8 +25,8 @@ class TestdroidAndroid(unittest.TestCase):
         ##
         self.screenshotDir = os.environ.get('TESTDROID_SCREENSHOTS') or "/absolute/path/to/desired/directory"
         testdroid_url = os.environ.get('TESTDROID_URL') or "https://cloud.testdroid.com"
-        testdroid_username = os.environ.get('TESTDROID_USERNAME') or "user@email.com"
-        testdroid_password = os.environ.get('TESTDROID_PASSWORD') or "password"
+        testdroid_apiKey = os.environ.get('TESTDROID_APIKEY') or ""
+        testdroid_app = os.environ.get('TESTDROID_APP') or ""
         appium_url = os.environ.get('TESTDROID_APPIUM_URL') or 'http://appium.testdroid.com/wd/hub'
 
         # Options to select device
@@ -37,7 +37,7 @@ class TestdroidAndroid(unittest.TestCase):
         deviceFinder = None
         testdroid_device = os.environ.get('TESTDROID_DEVICE') or ""
 
-        deviceFinder = DeviceFinder(username=testdroid_username, password=testdroid_password, url=testdroid_url)
+        deviceFinder = DeviceFinder(url=testdroid_url)
         if testdroid_device == "":
             # Loop will not exit until free device is found
             while testdroid_device == "":
@@ -47,16 +47,15 @@ class TestdroidAndroid(unittest.TestCase):
         print "Starting Appium test using device '%s'" % testdroid_device
 
         desired_capabilities_cloud = {}
-        desired_capabilities_cloud['testdroid_username'] = testdroid_username
-        desired_capabilities_cloud['testdroid_password'] = testdroid_password
+        desired_capabilities_cloud['testdroid_apiKey'] = testdroid_apiKey
         if apiLevel > 17:
             desired_capabilities_cloud['testdroid_target'] = 'Android'
         else:
             desired_capabilities_cloud['testdroid_target'] = 'Selendroid'
-        desired_capabilities_cloud['testdroid_project'] = os.environ.get('TESTDROID_PROJECT') or 'Appium Android demo'
+        desired_capabilities_cloud['testdroid_project'] = os.environ.get('TESTDROID_PROJECT') or 'Android demo'
         desired_capabilities_cloud['testdroid_testrun'] = os.environ.get('TESTDROID_TESTRUN') or 'My testrun'
         desired_capabilities_cloud['testdroid_device'] = testdroid_device
-        desired_capabilities_cloud['testdroid_app'] = 'sample/BitbarSampleApp.apk'
+        desired_capabilities_cloud['testdroid_app'] = testdroid_app
         #desired_capabilities_cloud['app'] = '/absolute/path/to/your/application.apk'
         desired_capabilities_cloud['platformName'] = 'Android'
         desired_capabilities_cloud['deviceName'] = 'Android Phone'

--- a/appium/sample-scripts/python/testdroid_android_hybrid.py
+++ b/appium/sample-scripts/python/testdroid_android_hybrid.py
@@ -4,122 +4,149 @@
 ##
 
 import os
-import sys
 import time
+import unittest
+from device_finder import DeviceFinder
 from time import sleep
 from selenium import webdriver
-
-
-appium_Url = 'http://appium.testdroid.com/wd/hub';
-
-##
-## IMPORTANT: Set the following parameters.
-##
-screenshotDir= "/absolute/path/to/desired/directory"
-testdroid_username = "username@example.com"
-testdroid_password = "p4s$w0rd"
-testdroid_device = "Dell Venue 7 3730" # Example device. Change if you desire.
 
 def log(msg):
     print (time.strftime("%H:%M:%S") + ": " + msg)
 
-screenShotCount = 1
-def screenshot(name):
-    global screenShotCount
-    screenshotName = str(screenShotCount) + "_" + name + ".png" 
-    log ("Taking screenshot: " + screenshotName)
-    sleep(1) # wait for animations to complete before taking screenshot
-    driver.save_screenshot(screenshotDir + "/" + screenshotName)
-    screenShotCount += 1
+class TestdroidAndroid(unittest.TestCase):
 
-desired_capabilities_cloud = {}
-desired_capabilities_cloud['testdroid_username'] = testdroid_username
-desired_capabilities_cloud['testdroid_password'] = testdroid_password
-desired_capabilities_cloud['testdroid_target'] = 'chrome'
-desired_capabilities_cloud['testdroid_project'] = 'Appium Android Hybrid Demo'
-desired_capabilities_cloud['testdroid_testrun'] = 'TestRun 1'
-desired_capabilities_cloud['testdroid_device'] = testdroid_device
-desired_capabilities_cloud['testdroid_app'] = 'sample/testdroid-sample.apk'
-desired_capabilities_cloud['platformName'] = 'Android'
-desired_capabilities_cloud['deviceName'] = 'Android Phone'
-desired_capabilities_cloud['automationName'] = 'selendroid'
-desired_capabilities_cloud['appPackage'] = 'com.testdroid.sample.android'
-desired_capabilities_cloud['appActivity'] = '.MA_MainActivity'
+    def screenshot(self, name):
+        self.screenShotCount = 1
+        screenshotName = str(self.screenShotCount) + "_" + name + ".png" 
+        log ("Taking screenshot: " + screenshotName)
+        sleep(1) # wait for animations to complete before taking screenshot
+        driver.save_screenshot(self.screenshotDir + "/" + screenshotName)
+        self.screenShotCount += 1
 
-desired_caps = desired_capabilities_cloud;
+    
+    def setUp(self):
 
-log ("Will save screenshots at: " + screenshotDir)
+        ##
+        ## IMPORTANT: Set the following parameters.
+        ## You can set the parameters outside the script with environment variables.
+        ## If env var is not set the string after or is used.
+        ##
+        self.screenshotDir = os.environ.get('TESTDROID_SCREENSHOTS') or "/absolute/path/to/desired/directory"
+        testdroid_url = os.environ.get('TESTDROID_URL') or "https://cloud.testdroid.com"
+        testdroid_apiKey = os.environ.get('TESTDROID_APIKEY') or ""
+        testdroid_app = os.environ.get('TESTDROID_APP') or ""
+        appium_url = os.environ.get('TESTDROID_APPIUM_URL') or 'http://appium.testdroid.com/wd/hub'
 
-# set up webdriver
-log ("WebDriver request initiated. Waiting for response, this typically takes 2-3 mins")
-driver = webdriver.Remote(appium_Url, desired_caps)
-log ("WebDriver response received")
+        # Options to select device
+        # 1) Set environment variable TESTDROID_DEVICE
+        # 2) Set device name to this python script
+        # 3) Do not set #1 and #2 and let DeviceFinder to find free device for you
 
-log ("Activity-1")
-log ("  Getting device screen size")
-print driver.get_window_size()
+        deviceFinder = None
+        testdroid_device = os.environ.get('TESTDROID_DEVICE') or ""
 
-screenshot("appLaunch")
+        deviceFinder = DeviceFinder(url=testdroid_url)
+        if testdroid_device == "":
+            # Loop will not exit until free device is found
+            while testdroid_device == "":
+                testdroid_device = deviceFinder.available_free_android_device()
 
-log('clicking button "hybrid app"')
-element=driver.find_element_by_id('com.testdroid.sample.android:id/mm_b_hybrid')
-element.click()
-screenshot('hybridActivity')
+        
+        desired_capabilities_cloud = {}
+        desired_capabilities_cloud['testdroid_apiKey'] = testdroid_apiKey
+        desired_capabilities_cloud['testdroid_target'] = 'chrome'
+        desired_capabilities_cloud['testdroid_project'] = 'Appium Android Hybrid Demo'
+        desired_capabilities_cloud['testdroid_testrun'] = 'TestRun 1'
+        desired_capabilities_cloud['testdroid_device'] = testdroid_device
+        desired_capabilities_cloud['testdroid_app'] = testdroid_app
+        desired_capabilities_cloud['platformName'] = 'Android'
+        desired_capabilities_cloud['deviceName'] = 'Android Phone'
+        desired_capabilities_cloud['automationName'] = 'selendroid'
+        desired_capabilities_cloud['appPackage'] = 'com.testdroid.sample.android'
+        desired_capabilities_cloud['appActivity'] = '.MA_MainActivity'
 
-log('Typing in the Url')
-element=driver.find_element_by_id('com.testdroid.sample.android:id/hy_et_url')
-element.send_keys("http://testdroid.com")
-screenshot('urlTyped')
+        desired_caps = desired_capabilities_cloud;
 
-log('hiding keyboard')
-driver.back()
-screenshot('keyboardHidden')
+        log ("Will save screenshots at: " + self.screenshotDir)
 
-log('clicking Load url button')
-element=driver.find_element_by_id('com.testdroid.sample.android:id/hy_ib_loadUrl')
-element.click()
-log('waiting 10 seconds for url to load completely')
-sleep(10)
-screenshot('webPageLoaded')
+        # set up webdriver
+        log ("WebDriver request initiated. Waiting for response, this typically takes 2-3 mins")
+        self.driver = webdriver.Remote(appium_url, desired_caps)
+        log ("WebDriver response received")
+        
+    def tearDown(self):
+        log ("Quitting")
+        self.driver.quit()
 
-log('finding window handles')
-handles = driver.window_handles
-for handle in driver.window_handles:
-    log("   > Window: " + handle)
+    def testSample(self):
+        log ("Activity-1")
+        log ("  Getting device screen size")
+        print self.driver.get_window_size()
 
-log('switching to webview')
-webview = handles[1]
-driver.switch_to_window(webview)
+        self.screenshot("appLaunch")
 
-log ("Clicking 'Products'")
-elem = driver.find_element_by_xpath('//*[@id="menu"]/ul/li[1]/a')
-elem.click()
-sleep(5)
-screenshot('webview_products')
+        log('clicking button "hybrid app"')
+        element=self.driver.find_element_by_id('com.testdroid.sample.android:id/mm_b_hybrid')
+        element.click()
+        self.screenshot('hybridActivity')
 
-log ("Clicking 'Learn More'")
-elem = driver.find_element_by_xpath('//*[@id="products"]/div[1]/div/div[1]/div[3]/a')
-elem.click()
-sleep(5)
-screenshot('webview_learnmore')
+        log('Typing in the Url')
+        element=self.driver.find_element_by_id('com.testdroid.sample.android:id/hy_et_url')
+        element.send_keys("http://testdroid.com")
+        self.screenshot('urlTyped')
 
-log ("Clicking 'Supported Frameworks'")
-elem = driver.find_element_by_xpath('//*[@id="topBox"]/div[1]/div/a[2]')
-elem.click()
-sleep(5)
-screenshot('webview_supportedframeworks')
+        log('hiding keyboard')
+        self.driver.back()
+        self.screenshot('keyboardHidden')
 
-log('finding window handles')
-handles = driver.window_handles
-for handle in driver.window_handles:
-    log("   > Window: " + handle)
+        log('clicking Load url button')
+        element=self.driver.find_element_by_id('com.testdroid.sample.android:id/hy_ib_loadUrl')
+        element.click()
+        log('waiting 10 seconds for url to load completely')
+        sleep(10)
+        self.screenshot('webPageLoaded')
 
-log('switching back to native app')
-nativeapp = handles[0]
-driver.switch_to_window(nativeapp)
+        log('finding window handles')
+        handles = self.driver.window_handles
+        for handle in self.driver.window_handles:
+            log("   > Window: " + handle)
 
-log('goint back')
-driver.back()
-screenshot('launchScreen')
+        log('switching to webview')
+        webview = handles[1]
+        self.driver.switch_to_window(webview)
 
-sys.exit()
+        log ("Clicking 'Products'")
+        elem = self.driver.find_element_by_xpath('//*[@id="menu"]/ul/li[1]/a')
+        elem.click()
+        sleep(5)
+        self.screenshot('webview_products')
+
+        log ("Clicking 'Learn More'")
+        elem = self.driver.find_element_by_xpath('//*[@id="products"]/div[1]/div/div[1]/div[3]/a')
+        elem.click()
+        sleep(5)
+        self.screenshot('webview_learnmore')
+
+        log ("Clicking 'Supported Frameworks'")
+        elem = self.driver.find_element_by_xpath('//*[@id="topBox"]/div[1]/div/a[2]')
+        elem.click()
+        sleep(5)
+        self.screenshot('webview_supportedframeworks')
+
+        log('finding window handles')
+        handles = self.driver.window_handles
+        for handle in self.driver.window_handles:
+            log("   > Window: " + handle)
+
+        log('switching back to native app')
+        nativeapp = handles[0]
+        self.driver.switch_to_window(nativeapp)
+
+        log('goint back')
+        self.driver.back()
+        self.screenshot('launchScreen')
+
+
+if __name__ == "__main__":
+    suite = unittest.TestLoader().loadTestsFromTestCase(TestdroidAndroid)
+    unittest.TextTestRunner(verbosity=2).run(suite)

--- a/appium/sample-scripts/python/testdroid_chrome.py
+++ b/appium/sample-scripts/python/testdroid_chrome.py
@@ -4,8 +4,8 @@
 ##
 
 import os
-import sys
 import time
+import unittest
 from time import sleep
 from selenium import webdriver
 from device_finder import DeviceFinder
@@ -13,76 +13,102 @@ from device_finder import DeviceFinder
 def log(msg):
     print (time.strftime("%H:%M:%S") + ": " + msg)
 
-appium_Url = 'http://appium.testdroid.com/wd/hub';
-#appium_Url = 'http://10.0.1.115:10010/wd/hub';
+class TestdroidAndroid(unittest.TestCase):
 
-##
-## IMPORTANT: Set the following parameters.
-##
-screenshotDir= "/absolute/path/to/desired/directory"
-testdroid_username = "user@example.com"
-testdroid_password = "p4s$w0rd"
+    def screenshot(self, name):
+        self.screenShotCount = 1
+        screenshotName = str(self.screenShotCount) + "_" + name + ".png" 
+        log ("Taking screenshot: " + screenshotName)
+        sleep(1) # wait for animations to complete before taking screenshot
+        self.driver.save_screenshot(self.screenshotDir + "/" + screenshotName)
+        self.screenShotCount += 1
 
-# Device can be manually defined, by device name found from Testdroid Cloud
-# testdroid_device = "Asus Memo Pad 8 K011"
-#
-# DeviceFinder can be used to find available free device for testing
-deviceFinder = DeviceFinder(testdroid_username, testdroid_password)
-testdroid_device = ""
-while testdroid_device == "":
-    testdroid_device = deviceFinder.available_free_android_device()
+    
+    def setUp(self):
 
-print "Starting Appium test using device '%s'" % testdroid_device
+        ##
+        ## IMPORTANT: Set the following parameters.
+        ## You can set the parameters outside the script with environment variables.
+        ## If env var is not set the string after or is used.
+        ##
+        self.screenshotDir = os.environ.get('TESTDROID_SCREENSHOTS') or "/absolute/path/to/desired/directory"
+        testdroid_url = os.environ.get('TESTDROID_URL') or "https://cloud.testdroid.com"
+        testdroid_apiKey = os.environ.get('TESTDROID_APIKEY') or ""
+#        testdroid_app = os.environ.get('TESTDROID_APP') or ""
+        appium_url = os.environ.get('TESTDROID_APPIUM_URL') or 'http://appium.testdroid.com/wd/hub'
 
-desired_capabilities_cloud = {}
-desired_capabilities_cloud['testdroid_username'] = testdroid_username
-desired_capabilities_cloud['testdroid_password'] = testdroid_password
-desired_capabilities_cloud['testdroid_target'] = 'chrome'
-desired_capabilities_cloud['testdroid_project'] = 'Appium Chrome Demo'
-desired_capabilities_cloud['testdroid_testrun'] = 'TestRun A'
-desired_capabilities_cloud['testdroid_device'] = testdroid_device
-desired_capabilities_cloud['platformName'] = 'Android'
-desired_capabilities_cloud['deviceName'] = 'AndroidDevice'
-desired_capabilities_cloud['browserName'] = 'chrome'
+        # Options to select device
+        # 1) Set environment variable TESTDROID_DEVICE
+        # 2) Set device name to this python script
+        # 3) Do not set #1 and #2 and let DeviceFinder to find free device for you
 
-desired_caps = desired_capabilities_cloud;
+        deviceFinder = None
+        testdroid_device = os.environ.get('TESTDROID_DEVICE') or "Samsung Galaxy Tab 3 10.1 GT-P5210 4.4.2"
 
-log ("Will save screenshots at: " + screenshotDir)
+        deviceFinder = DeviceFinder(url=testdroid_url)
+        if testdroid_device == "":
+            # Loop will not exit until free device is found
+            while testdroid_device == "":
+                testdroid_device = deviceFinder.available_free_android_device()
 
-# set up webdriver
-log ("WebDriver request initiated. Waiting for response, this typically takes 2-3 mins")
-driver = webdriver.Remote(appium_Url, desired_caps)
+        
+        desired_capabilities_cloud = {}
+        desired_capabilities_cloud['testdroid_apiKey'] = testdroid_apiKey
+        desired_capabilities_cloud['testdroid_target'] = 'chrome'
+        desired_capabilities_cloud['testdroid_project'] = 'Appium Chrome Demo'
+        desired_capabilities_cloud['testdroid_testrun'] = 'TestRun A'
+        desired_capabilities_cloud['testdroid_device'] = testdroid_device
+#        desired_capabilities_cloud['testdroid_app'] = testdroid_app
+        desired_capabilities_cloud['platformName'] = 'Android'
+        desired_capabilities_cloud['deviceName'] = 'AndroidDevice'
+        desired_capabilities_cloud['browserName'] = 'chrome'
 
-log ("Loading page http://testdroid.com")
-driver.get("http://testdroid.com")
+        desired_caps = desired_capabilities_cloud;
 
-log ("Taking screenshot of home page: '1_home.png'")
-driver.save_screenshot(screenshotDir + "/1_home.png")
+        log ("Will save screenshots at: " + self.screenshotDir)
 
-log ("Finding 'Products'")
-elem = driver.find_element_by_xpath('//*[@id="menu"]/ul/li[1]/a')
-log ("Clicking 'Products'")
-elem.click()
+        # set up webdriver
+        log ("WebDriver request initiated. Waiting for response, this typically takes 2-3 mins")
+        self.driver = webdriver.Remote(appium_url, desired_caps)
 
-log ("Taking screenshot of 'Products' page: '2_products.png'")
-driver.save_screenshot(screenshotDir + "/2_products.png")
+        log ("Loading page http://testdroid.com")
+        self.driver.get("http://testdroid.com")
 
-log ("Finding 'Learn More'")
-elem = driver.find_element_by_xpath('//*[@id="products"]/div[1]/div/div[1]/div[3]/a')
-log ("Clicking 'Learn More'")
-elem.click()
+    def tearDown(self):
+        log ("Quitting")
+        self.driver.quit()
 
-log ("Taking screenshot of 'Learn More' page: '3_learnmore.png'")
-driver.save_screenshot(screenshotDir + "/3_learnmore.png")
+    def testSample(self):
+        log ("Taking screenshot of home page: '1_home.png'")
+        self.driver.save_screenshot(self.screenshotDir + "/1_home.png")
 
-log ("Finding 'Supported Frameworks'")
-elem = driver.find_element_by_xpath('//*[@id="topBox"]/div[1]/div/a[2]')
-log ("Clicking 'Supported Frameworks'")
-elem.click()
+        log ("Finding 'Products'")
+        elem = self.driver.find_element_by_xpath('//*[@id="menu"]/ul/li[1]/a')
+        log ("Clicking 'Products'")
+        elem.click()
+    
+        log ("Taking screenshot of 'Products' page: '2_products.png'")
+        self.driver.save_screenshot(self.screenshotDir + "/2_products.png")
+        
+        log ("Finding 'Learn More'")
+        elem = self.driver.find_element_by_xpath('//*[@id="products"]/div[1]/div/div[1]/div[3]/a')
+        log ("Clicking 'Learn More'")
+        elem.click()
 
-log ("Taking screenshot of 'Supported Framworks' page: '4_supportedframeworks.png'")
-driver.save_screenshot(screenshotDir + "/4_supportedframeworks.png")
+        log ("Taking screenshot of 'Learn More' page: '3_learnmore.png'")
+        self.driver.save_screenshot(self.screenshotDir + "/3_learnmore.png")
 
-log ("quitting")
-driver.quit()
-sys.exit()
+        log ("Finding 'Supported Frameworks'")
+        elem = self.driver.find_element_by_xpath('//*[@id="topBox"]/div[1]/div/a[2]')
+        log ("Clicking 'Supported Frameworks'")
+        elem.click()
+
+        log ("Taking screenshot of 'Supported Framworks' page: '4_supportedframeworks.png'")
+        self.driver.save_screenshot(self.screenshotDir + "/4_supportedframeworks.png")
+
+        log ("quitting")
+
+
+if __name__ == "__main__":
+    suite = unittest.TestLoader().loadTestsFromTestCase(TestdroidAndroid)
+    unittest.TextTestRunner(verbosity=2).run(suite)

--- a/appium/sample-scripts/python/testdroid_ios.py
+++ b/appium/sample-scripts/python/testdroid_ios.py
@@ -22,8 +22,8 @@ class TestdroidIOS(unittest.TestCase):
         ##
         testdroid_url = os.environ.get('TESTDROID_URL') or "https://cloud.testdroid.com"
         appium_url = os.environ.get('TESTDROID_APPIUM_URL') or 'http://appium.testdroid.com/wd/hub'
-        testdroid_username = os.environ.get('TESTDROID_USERNAME') or "user@email.com"
-        testdroid_password = os.environ.get('TESTDROID_PASSWORD') or "password"
+        testdroid_apiKey = os.environ.get('TESTDROID_APIKEY') or ""
+        testdroid_app = os.environ.get('TESTDROID_APP') or ""
         self.screenshot_dir = os.environ.get('TESTDROID_SCREENSHOTS') or "/absolute/path/to/desired/directory"
         testdroid_project_name = os.environ.get('TESTDROID_PROJECT') or "Appium iOS demo"
         testdroid_testrun_name = os.environ.get('TESTDROID_TESTRUN') or "My testrun"
@@ -37,7 +37,7 @@ class TestdroidIOS(unittest.TestCase):
         testdroid_device = os.environ.get('TESTDROID_DEVICE') or ""
 
         if testdroid_device == "":
-            deviceFinder = DeviceFinder(username=testdroid_username, password=testdroid_password, url=testdroid_url)
+            deviceFinder = DeviceFinder(url=testdroid_url)
             # Loop will not exit until free device is found
             while testdroid_device == "":
                 testdroid_device = deviceFinder.available_free_ios_device()
@@ -45,14 +45,13 @@ class TestdroidIOS(unittest.TestCase):
         print "Starting Appium test using device '%s'" % testdroid_device
 
         desired_capabilities_cloud={
-                'testdroid_username': testdroid_username,
-                'testdroid_password': testdroid_password,
+                'testdroid_apiKey': testdroid_apiKey,
                 'testdroid_project': testdroid_project_name,
                 'testdroid_target': 'ios',
                 'testdroid_description': 'Appium project description',
                 'testdroid_testrun': testdroid_testrun_name,
                 'testdroid_device': testdroid_device,
-                'testdroid_app': 'sample/BitbarIOSSample.ipa',
+                'testdroid_app': testdroid_app,
                 'platformName': 'iOS',
                 'deviceName': 'iPhone device',
                 'bundleId': 'com.bitbar.testdroid.BitbarIOSSample',

--- a/appium/sample-scripts/python/testdroid_ios.py
+++ b/appium/sample-scripts/python/testdroid_ios.py
@@ -46,21 +46,21 @@ class TestdroidIOS(unittest.TestCase):
 
         desired_capabilities_cloud={
                 'testdroid_apiKey': testdroid_apiKey,
-                'testdroid_project': testdroid_project_name,
                 'testdroid_target': 'ios',
-                'testdroid_description': 'Appium project description',
+                'testdroid_project': testdroid_project_name,
                 'testdroid_testrun': testdroid_testrun_name,
                 'testdroid_device': testdroid_device,
                 'testdroid_app': testdroid_app,
+                'testdroid_description': 'Appium project description',
                 'platformName': 'iOS',
                 'deviceName': 'iPhone device',
                 'bundleId': 'com.bitbar.testdroid.BitbarIOSSample',
         }
-        
+
         # set up webdriver
         log ("WebDriver request initiated. Waiting for response, this typically takes 2-3 mins")
 
-        self.driver = webdriver.Remote(command_executor=appium_url,desired_capabilities=desired_capabilities_cloud)
+        self.driver = webdriver.Remote(command_executor=appium_url, desired_capabilities=desired_capabilities_cloud)
         log ("WebDriver response received")
 
 

--- a/appium/sample-scripts/python/testdroid_safari.py
+++ b/appium/sample-scripts/python/testdroid_safari.py
@@ -28,25 +28,27 @@ class TestdroidSafari(unittest.TestCase):
         ##
         ## IMPORTANT: Set the following parameters.
         ##
-        self.screenshotDir= "/absolute/path/to/desired/directory"
-        testdroid_username = "username@example.com"
-        testdroid_password = "p4s$w0rd"
+        self.screenshot_dir = os.environ.get('TESTDROID_SCREENSHOTS') or "/absolute/path/to/desired/directory"
+        testdroid_apiKey = os.environ.get('TESTDROID_APIKEY') or ""
 
-        ## Device can be manually defined, by device name found from Testdroid Cloud
-        testdroid_device = "iPhone 5 A1429 6.1.4"
+        # Options to select device
+        # 1) Set environment variable TESTDROID_DEVICE
+        # 2) Set device name to this python script
+        # 3) Do not set #1 and #2 and let DeviceFinder to find free device for you
 
-        # ## DeviceFinder can be used to find available freemium device for testing
-        # deviceFinder = DeviceFinder(testdroid_username, testdroid_password)
-        # testdroid_device = ""
-        # ## Safari testing iPad 3 freemium device not yet supported as it is iOS 8.2 device
-        # while testdroid_device == "" or testdroid_device == "iPad 3 A1416 8.2":
-        #     testdroid_device = deviceFinder.available_free_ios_device()
-            
+        deviceFinder = None
+        testdroid_device = os.environ.get('TESTDROID_DEVICE') or "iPhone 5 A1429 6.1.4"
+
+        if testdroid_device == "":
+            deviceFinder = DeviceFinder(url=testdroid_url)
+            # Loop will not exit until free device is found
+            while testdroid_device == "":
+                testdroid_device = deviceFinder.available_free_ios_device()
+
         print "Starting Appium test using device '%s'" % testdroid_device
 
         desired_capabilities_cloud = {}
-        desired_capabilities_cloud['testdroid_username'] = testdroid_username
-        desired_capabilities_cloud['testdroid_password'] = testdroid_password
+        desired_capabilities_cloud['testdroid_apiKey'] = testdroid_apiKey
         desired_capabilities_cloud['testdroid_target'] = 'safari'
         desired_capabilities_cloud['testdroid_project'] = 'Appium Safari Demo'
         desired_capabilities_cloud['testdroid_testrun'] = 'TestRun A'
@@ -56,7 +58,7 @@ class TestdroidSafari(unittest.TestCase):
         desired_capabilities_cloud['browserName'] = 'Safari'
         desired_caps = desired_capabilities_cloud;
         
-        log ("Will save screenshots at: " + self.screenshotDir)
+        log ("Will save screenshots at: " + self.screenshot_dir)
         
         # Set up webdriver
         log ("WebDriver request initiated. Waiting for response, this typically takes 2-3 mins")
@@ -78,7 +80,7 @@ class TestdroidSafari(unittest.TestCase):
             
             sleep(3)
             #log("Taking a screenshot")
-            #self.driver.save_screenshot(self.screenshotDir + '/testdroidcom.png')
+            #self.driver.save_screenshot(self.screenshot_dir + '/testdroidcom.png')
             
             # Finding element xpath, id or name is simple with Appium GUI application's inspector.
             # Safari Web Inspector can also be used on iOS devices.

--- a/appium/sample-scripts/python/testdroid_safari.py
+++ b/appium/sample-scripts/python/testdroid_safari.py
@@ -30,6 +30,7 @@ class TestdroidSafari(unittest.TestCase):
         ##
         self.screenshot_dir = os.environ.get('TESTDROID_SCREENSHOTS') or "/absolute/path/to/desired/directory"
         testdroid_apiKey = os.environ.get('TESTDROID_APIKEY') or ""
+        testdroid_url = os.environ.get('TESTDROID_URL') or "https://cloud.testdroid.com"
 
         # Options to select device
         # 1) Set environment variable TESTDROID_DEVICE
@@ -37,8 +38,9 @@ class TestdroidSafari(unittest.TestCase):
         # 3) Do not set #1 and #2 and let DeviceFinder to find free device for you
 
         deviceFinder = None
-        testdroid_device = os.environ.get('TESTDROID_DEVICE') or "iPhone 5 A1429 6.1.4"
+        testdroid_device = os.environ.get('TESTDROID_DEVICE') or ""
 
+        deviceFinder = DeviceFinder(url=testdroid_url)
         if testdroid_device == "":
             deviceFinder = DeviceFinder(url=testdroid_url)
             # Loop will not exit until free device is found

--- a/appium/sample-scripts/python/upload.py
+++ b/appium/sample-scripts/python/upload.py
@@ -18,7 +18,7 @@ def build_headers():
             'Accept' : 'application/json' }
     return hdrs
 
-files = {'file': ('Testdroid.apk', open(myfile, 'rb'), 'application/octet-stream')}
+files = {'file': (os.path.basename(myfile), open(myfile, 'rb'), 'application/octet-stream')}
 r = requests.post(upload_url, files=files, headers=build_headers())
 
 if  "successful" in r.json()['value']['message']:

--- a/appium/sample-scripts/python/upload.py
+++ b/appium/sample-scripts/python/upload.py
@@ -4,16 +4,23 @@
 
 import requests
 import base64
+import os
+import json
 
-username = 'USERNAME'
-password = 'PASSWORD'
+# update your apiKey value here or export it to your environment
+api_key = os.environ.get('TESTDROID_APIKEY') or "<api key value here>"
 upload_url = 'http://appium.testdroid.com/upload'
 myfile = '../../../apps/builds/Testdroid.apk'
 
 def build_headers():
-  return { 'Authorization' : 'Basic %s' % base64.b64encode(username+":"+password) }
+    hdrs = {'Authorization' : 'Basic %s' % base64.b64encode(api_key+":"),
+            'Accept' : 'application/json' }
+    return hdrs
 
 files = {'file': ('Testdroid.apk', open(myfile, 'rb'), 'application/octet-stream')}
 r = requests.post(upload_url, files=files, headers=build_headers())
-print r.text
 
+if  "successful" in r.json()['value']['message']:
+    print "Filename to use in testdroid capabilities in your test: {}".format(r.json()['value']['uploads']['file'])
+else:
+    print "Upload response: \n{}".format(r.json())

--- a/appium/sample-scripts/python/upload.py
+++ b/appium/sample-scripts/python/upload.py
@@ -8,9 +8,10 @@ import os
 import json
 
 # update your apiKey value here or export it to your environment
+# and you app path if you want to upload your own app instead of demo app
 api_key = os.environ.get('TESTDROID_APIKEY') or "<api key value here>"
 upload_url = 'http://appium.testdroid.com/upload'
-myfile = '../../../apps/builds/Testdroid.apk'
+myfile = os.environ.get('TESTDROID_APP_PATH') or '../../../apps/builds/Testdroid.apk'
 
 def build_headers():
     hdrs = {'Authorization' : 'Basic %s' % base64.b64encode(api_key+":"),


### PR DESCRIPTION
All scripts have now same unittest structure. 
Device finder does not use oauth anymore as it was unnecessary. 
All tests now use apiKey for identification instead of username & password.
Upload.py - removed hard coded app name, now works with ios apps too. 
