### PR TITLE
Akaze repo link to Bitbar repo

### DIFF
--- a/image-recognition/README.md
+++ b/image-recognition/README.md
@@ -18,7 +18,7 @@ The project uses:
 - testdroid-appium-driver - can be downloaded from
   [https://github.com/bitbar/testdroid-appium-driver.git](https://github.com/bitbar/testdroid-appium-driver.git)
 
-- [Testdroid Akaze](https://github.com/aknackiron/akaze) - fork of official Akaze repo with added json support.
+- [Testdroid Akaze](https://github.com/bitbar/akaze) - fork of official Akaze repo with added json support.
 
 - [OpenCV](http://opencv.org/)
 
@@ -199,13 +199,14 @@ linking errors while linking Akaze.
 
    *pom.xml* file needs to be updated with installed OpenCV version (2.4.12 in this example).
 
-1. [Akaze](https://github.com/aknackiron/akaze)
+1. [Akaze](https://github.com/bitbar/akaze.git)
 
    ```
-   git clone https://github.com/aknackiron/akaze.git
+   git clone https://github.com/bitbar/akaze.git
    cd akaze
    # copy previously built versions of jsoncpp to 'src/lib/jsoncpp/', 'src/lib/json/' and src/lib/jsoncpp.cpp
-   cp -r path/to/jsoncpp/dist/json ./src/lib/
+   mkdir ./src/lib/jsoncpp/
+   cp -r path/to/jsoncpp/dist/json ./src/lib/jsoncpp/
    cp -r path/to/jsoncpp/dist/jsoncpp.cpp ./src/lib/
    mkdir build
    cd build


### PR DESCRIPTION
Updated with Bitbar Akaze repo, fixed location to copy jsoncpp files under Akaze directory.