### PR TITLE
new run-text.py taking command line params and launching test to run

### DIFF
--- a/appium/sample-scripts/python/README.md
+++ b/appium/sample-scripts/python/README.md
@@ -1,3 +1,5 @@
+
+
 # Appium Python Samples
 
 Testdroid can be used to run Appium tests against real devices to test
@@ -8,36 +10,60 @@ You'll find here all steps you need to start running your mobile tests
 against real devices in Testdroid Cloud. Before continuing with running with
 these scripts you should register with [Testdroid service](https://cloud.testdroid.com/).
 
-For more detailed guides on Appium please refer to their excellent
+For more detailed guides on Appium please refer to their
 [documentation
 online](http://appium.io/slate/en/master/?python#about-appium).
 
-## Upload Your App To Cloud
+# Uploading Your App To Cloud
 
-Before testing can start you need to upload you mobile application to
-the cloud. To do so open and configure the upload.py script. You will
-need to add your apiKey value that you can get from under "My Account"
-from Testdroid cloud. Also you'll need to set the full path to your
-mobile app. This can be an Android or iOS application.
+Uploading an app is easiest using the `upload.py` script and using
+apiKey identification. The apiKey is found under "My Account" in
+Testdroid Cloud. For the upload to be successful the full path to the
+app (apk or ipa) needs to be provided.
 
-```sh
-$ python upload.py 
-Filename to use in testdroid capabilities in your test: 719f52c4-2c34-4c25-b90b-08884f049d3a/Testdroid.apk
+If no app is provided on command line, then the Bitbar Sample Android app is uploaded.
+
+```bash
+$ python upload.py -h
+usage: upload.py [-h] [-k APIKEY] [-a APP_PATH] [-u URL]
+
+Upload a mobile app to Testdroid Cloud and get a handle to it
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -k APIKEY, --apikey APIKEY
+                        User's apiKey to identify to cloud, or set environment
+                        variable TESTDROID_APIKEY
+  -a APP_PATH, --app_path APP_PATH
+                        Path to app to upload or set environment variable
+                        TESTDROID_APP_PATH. Current value is:
+                        '../../../apps/builds/Testdroid.apk'
+  -u URL, --url URL     Testdroid Cloud url to upload app or set environment
+                        variable TESTDROID_UPLOAD_URL. Current value is:
+                        'http://appium.testdroid.com/upload'
 ```
 
-From the response message you need to store the application's file
-name in the cloud. In this example upload it is
-'719f52c4-2c34-4c25-b90b-08884f049d3a/Testdroid.apk'.
+The below example shows how to upload a hybrid Android demo app to Testdroid Cloud.
 
-## Common Settings
+```bash
+$ python upload.py -k xg8x...YXto -u ../../../apps/builds/Testdroid.apk
+Filename to use in testdroid capabilities in your test: 719f52c4-43c2-4c25-b91b-08884f049d3a/Testdroid.apk
+```
 
-There are some common settings that you need to set in all scripts
-regardless of the app type that you are testing. Each testdroid_*.py
-file needs to be updated with the following values.
+The response message provides the application's cloud file
+name that is needed to start testing against the app. From the above example the path to store is:
+'719f52c4-43c2-4c25-b90b-08884f049d3a/Testdroid.apk'.
 
-Here are all the values that you need to edit:
 
-* *screenshotDir* - where should screenshots be stored on your local drive
+# Common Settings in Example Tests
+
+There are some common settings needed to run any of the example tests, 
+regardless of the app type being tested. Each `testdroid_*.py`
+file needs to have the following values set as environment variables. Values can also be given as command line parameters to `run-test.py` script.
+
+Common values used in tests:
+
+* *screenshot_dir* - where should screenshots be stored on your local drive
 
 * *testdroid_username* - your email that you registered with to
    Testdroid Cloud.  **Rather use testdroid_apiKey.**
@@ -45,65 +71,122 @@ Here are all the values that you need to edit:
 * *testdroid_password* - your Testdroid Cloud password. **Rather use
    testdroid_apiKey.**
 
-* *testdroid_apiKey* - a personal unique key that allows you to
-   connect to Testdroid Cloud without the need to use your username
-   and passwords in your tests. You can find your api key under "My
-   account" in [Testdroid Cloud](https://cloud.testdroid.com/) UI.
+* *testdroid_apiKey* - a personal unique key allowing you to connect
+   to Testdroid Cloud without using username and passwords in
+   tests. Api key is found under "My account" in [Testdroid
+   Cloud](https://cloud.testdroid.com/) UI.
 
-* *testdroid_project* - you can set this value as an environment variable
-  or set in the script. This is the name you want to give to your
-  project in Testdroid Cloud. Each project must have a unique name, 
-  which can also be modified later
+* *testdroid_project* - the project name in Testdroid Cloud. Each
+  project must have a unique name, which can be modified (in Cloud)
 
-* *testdroid_testrun* - name of this test run. Is set here or read from
-  environment variable. Test run names can also be modified, even for
-  every test run
+* *testdroid_testrun* - name of this test run inside of
+  `testdroid_project`. Each test run can have it's own name (eg. date + time)
 
-* *testdroid_app* - should be the name of the app you uploaded to
-  cloud. Eg. if you uploaded your app using the upload.py script this
-  would look like 'f4660af0-10f3-46e9-932b-0622f497b0d2/Testdroid.apk'
-  You can also use the value *latest* if you want to rerun a test
-  against your last uploaded app.
+* *testdroid_app* - name of the app uploaded using `upload.py`
+  script. Example filename could be
+  'f4660af0-10f4-46e9-932b-0622f497b0d2/Testdroid.apk' To rerun using
+  last uploaded app testdroid_app can be set to *latest*
+
+## Example Run
+
+```bash
+$ python run-test.py -k xYY5...PeOA6 -d /tmp/screens/ -p "iOS" -t testdroid_ios -m "" -a "latest"
+testSample (testdroid_ios.TestdroidIOS) ... Searching Available Free iOS Device...
+Found device 'Apple iPad Mini A1432 9.2.1'
+
+Starting Appium test using device 'Apple iPad Mini A1432 9.2.1'
+15:59:00: WebDriver request initiated. Waiting for response, this typically takes 2-3 mins
+15:59:58: WebDriver response received
+15:59:58: view1: Finding buttons
+15:59:59: view1: Clicking button [0] - RadioButton 1
+16:00:00: view1: Typing in textfield[0]: Testdroid user
+16:00:08: view1: Tapping at position (384, 0.95) - Estimated position of SpaceBar
+16:00:10: view1: Taking screenshot screenshot1.png
+16:00:14: view1: Hiding Keyboard
+16:00:17: view1: Taking screenshot screenshot2.png
+16:00:21: view1: Clicking button[6] - OK  Button
+16:00:22: view2: Taking screenshot screenshot3.png
+16:00:26: view2: Finding buttons
+16:00:28: view2: Clicking button[0] - Back/OK button
+16:00:29: view1: Finding buttons
+16:00:30: view1: Clicking button[2] - RadioButton 2
+16:00:31: view1: Clicking button[6] - OK Button
+16:00:32: view1: Taking screenshot screenshot4.png
+16:00:36: view1: Sleeping 3 before quitting webdriver.
+16:00:39: Quitting
+ok
+
+```
+
+## Native iOS Example
+
+Example script: `testdroid_ios.py`
+
+To run iOS native app tests additional parameter is required to be provided:
+
+* **bundleId** - this is your application's unique name
+
+```bash
+$ python run-test.py -k xYY5...PeOA6 -d /tmp/screens/ -p "iOS" -r `date +%R` -a "latest" --bundle_id "com.bitbar.testdroid.BitbarIOSSample" -t testdroid_ios -m "" 
+```
+
+This parameter is not needed if running against the sample BitbarIOSSample.ipa application, as it's set inside of the sample script.
 
 
-## Native iOS Specific Settings
+## Native Android Example
 
-Example script: testdroid_ios.py
+Example script: `testdroid_android.py`
 
-To run your Appium tests against your native iOS application with real
-devices you need to edit the testdroid_ios.py script.
+To run an Appium test against a native Android application Appium needs to the following additional information:
 
-In addition to the above mentioned Appium capabilities for iOS testing
-you need set
+* **app_package** - Java package of the Android app you want to run
 
-* bundleId - this is your application's unique name
-
-## Native Android Specific Settings
-
-Example script: testdroid_android.py
-
-To configure this script for testing your own app, in addition to the
-common settings done above, you need to change the following values.
-
-* appPackage - Java package of the Android app you want to run
-
-* appActivity - activity name for the Android activity you want to
+* **app_activity** - activity name for the Android activity you want to
   launch from your package. Typically this is the main activity.
+
+For running the sample applications and tests these do not need to be set as they are set inside of the sample scripts if no parameter is given.
+
+```bash
+python run-test.py -k xYY5...PeOA6 -d /tmp/screens -a 830571c8-51f1-4cd1-ad91-82e76c00a1b0/BitbarSampleApp.apk -p "Android Native" -r  `date +%R` -m "" -t testdroid_android
+```
 
 ## Hybrid Android Specific Settings
 
-Example: testdroid_android_hybrid.py
+Example: `testdroid_android_hybrid.py`
 
-For a more complete explanation on testing hybrid application take a look at Appium [documentation](https://github.com/appium/appium/blob/master/docs/en/advanced-concepts/hybrid.md).
+Additional parameters needed to run a hybrid app:
 
+* **app_package** - Java package of the Android app you want to run
 
+* **app_activity** - activity name for the Android activity you want to
+  launch from your package. Typically this is the main activity.
 
-## Tips
+The above parameters are already set into the test scripts, so they are not mandatory for the sample tests. For other apps they are.
 
-* To run tests against your previous app you can simply set your
-  testdroid_app desired capability value to 'latest'
+```bash
+python run-test.py -k xYY5...PeOA6 -d /tmp/screens/ -t testdroid_android_hybrid -p "Android Hybrid"  -r `date +%R` --app b9608704-b55d-4b71-83d4-d8027c67b49a/Testdroid.apk --device ""
+```
 
+## Safari Browser Testing
 
-## License
+Does not need any specific settings.
+
+Example: `testdroid_safari.py`
+
+```bash
+python run-test.py -k xYY5hc8PXAXsBBd1G3ijnb18wlqPeOA6 -d /tmp/screens/ -t testdroid_safari -p "Safari browser"  -r `date +%R`
+```
+
+##  Chrome Browser Testing
+
+Does not need any special settings.
+
+Example: `testdroid_chrome.py`
+
+```bash
+python run-test.py -k xYY5hc8PXAXsBBd1G3ijnb18wlqPeOA6 -d /tmp/screens/ -t testdroid_chrome -p "Chrome browser"  -r `date +%R`
+```
+
+# License
 
 See the [LICENSE](https://github.com/bitbar/testdroid-samples/blob/master/LICENSE) file.

--- a/appium/sample-scripts/python/README.md
+++ b/appium/sample-scripts/python/README.md
@@ -50,16 +50,19 @@ $ python upload.py -k xg8x...YXto -u ../../../apps/builds/Testdroid.apk
 Filename to use in testdroid capabilities in your test: 719f52c4-43c2-4c25-b91b-08884f049d3a/Testdroid.apk
 ```
 
-The response message provides the application's cloud file
-name that is needed to start testing against the app. From the above example the path to store is:
+The response message provides the application's cloud file name that
+is the path to use with `testdroid_app` capability. From the above
+example the path to store is:
 '719f52c4-43c2-4c25-b90b-08884f049d3a/Testdroid.apk'.
 
 
 # Common Settings in Example Tests
 
-There are some common settings needed to run any of the example tests, 
-regardless of the app type being tested. Each `testdroid_*.py`
-file needs to have the following values set as environment variables. Values can also be given as command line parameters to `run-test.py` script.
+There are some common settings needed to run any of the example tests,
+regardless of the app type being tested. Each `testdroid_*.py` file
+needs to have the following values set as environment variables or set
+in the files. Values can also be given as command line parameters to
+`run-test.py` script.
 
 Common values used in tests:
 
@@ -77,10 +80,13 @@ Common values used in tests:
    Cloud](https://cloud.testdroid.com/) UI.
 
 * *testdroid_project* - the project name in Testdroid Cloud. Each
-  project must have a unique name, which can be modified (in Cloud)
+  project's name is unique. A project's name can be modified later on if needed.
 
 * *testdroid_testrun* - name of this test run inside of
-  `testdroid_project`. Each test run can have it's own name (eg. date + time)
+  `testdroid_project`. Each test run can have the same name, but it is
+  recommended to set it dynamically (e.g. with timestamp or device
+  name). If no test run name is given, the system automatically names
+  it in "Test Run x".
 
 * *testdroid_app* - name of the app uploaded using `upload.py`
   script. Example filename could be
@@ -90,7 +96,7 @@ Common values used in tests:
 ## Example Run
 
 ```bash
-$ python run-test.py -k xYY5...PeOA6 -d /tmp/screens/ -p "iOS" -t testdroid_ios -m "" -a "latest"
+$ python run-test.py -k xYY5...PeOA6 -s /tmp/screens/ -p "iOS" -t testdroid_ios -m "" -a "latest"
 testSample (testdroid_ios.TestdroidIOS) ... Searching Available Free iOS Device...
 Found device 'Apple iPad Mini A1432 9.2.1'
 
@@ -127,7 +133,7 @@ To run iOS native app tests additional parameter is required to be provided:
 * **bundleId** - this is your application's unique name
 
 ```bash
-$ python run-test.py -k xYY5...PeOA6 -d /tmp/screens/ -p "iOS" -r `date +%R` -a "latest" --bundle_id "com.bitbar.testdroid.BitbarIOSSample" -t testdroid_ios -m "" 
+$ python run-test.py -k xYY5...PeOA6 -s /tmp/screens/ -p "iOS" -r `date +%R` -a "latest" --bundle_id "com.bitbar.testdroid.BitbarIOSSample" -t testdroid_ios -m "" 
 ```
 
 This parameter is not needed if running against the sample BitbarIOSSample.ipa application, as it's set inside of the sample script.
@@ -147,7 +153,7 @@ To run an Appium test against a native Android application Appium needs to the f
 For running the sample applications and tests these do not need to be set as they are set inside of the sample scripts if no parameter is given.
 
 ```bash
-python run-test.py -k xYY5...PeOA6 -d /tmp/screens -a 830571c8-51f1-4cd1-ad91-82e76c00a1b0/BitbarSampleApp.apk -p "Android Native" -r  `date +%R` -m "" -t testdroid_android
+python run-test.py -k xYY5...PeOA6 -s /tmp/screens -a 830571c8-51f1-4cd1-ad91-82e76c00a1b0/BitbarSampleApp.apk -p "Android Native" -r  `date +%R` -m "" -t testdroid_android
 ```
 
 ## Hybrid Android Specific Settings
@@ -164,7 +170,7 @@ Additional parameters needed to run a hybrid app:
 The above parameters are already set into the test scripts, so they are not mandatory for the sample tests. For other apps they are.
 
 ```bash
-python run-test.py -k xYY5...PeOA6 -d /tmp/screens/ -t testdroid_android_hybrid -p "Android Hybrid"  -r `date +%R` --app b9608704-b55d-4b71-83d4-d8027c67b49a/Testdroid.apk --device ""
+python run-test.py -k xYY5...PeOA6 -s /tmp/screens/ -t testdroid_android_hybrid -p "Android Hybrid"  -r `date +%R` --app b9608704-b55d-4b71-83d4-d8027c67b49a/Testdroid.apk 
 ```
 
 ## Safari Browser Testing
@@ -174,7 +180,7 @@ Does not need any specific settings.
 Example: `testdroid_safari.py`
 
 ```bash
-python run-test.py -k xYY5hc8PXAXsBBd1G3ijnb18wlqPeOA6 -d /tmp/screens/ -t testdroid_safari -p "Safari browser"  -r `date +%R`
+python run-test.py -k xYY5hc8PXAXsBBd1G3ijnb18wlqPeOA6 -s /tmp/screens/ -t testdroid_safari -p "Safari browser"  -r `date +%R`
 ```
 
 ##  Chrome Browser Testing
@@ -184,7 +190,7 @@ Does not need any special settings.
 Example: `testdroid_chrome.py`
 
 ```bash
-python run-test.py -k xYY5hc8PXAXsBBd1G3ijnb18wlqPeOA6 -d /tmp/screens/ -t testdroid_chrome -p "Chrome browser"  -r `date +%R`
+python run-test.py -k xYY5hc8PXAXsBBd1G3ijnb18wlqPeOA6 -s /tmp/screens/ -t testdroid_chrome -p "Chrome browser"  -r `date +%R`
 ```
 
 # License

--- a/appium/sample-scripts/python/run-test.py
+++ b/appium/sample-scripts/python/run-test.py
@@ -1,0 +1,101 @@
+import os
+import argparse
+import unittest
+import importlib
+
+
+class TestdroidTestRunner():
+    def __init__(self):
+        self.variables = {"TESTDROID_APIKEY":"", 
+                               "TESTDROID_SCREENSHOTS":"",
+                               "TESTDROID_APP":"",
+                               "TESTDROID_DEVICE":""}
+        self.available_tests = ['testdroid_chrome', 'testdroid_android',
+                                    'testdroid_safari', 'testdroid_ios',
+                                    'testdroid_android_hybrid', 
+                                    'testdroid_native_browser']
+
+
+    def parse_args(self):
+        parser = argparse.ArgumentParser(description='Set needed environment variables for sample Testdroid tests')
+        parser.add_argument('-k', '--apikey', type=str, required=True, help="User's apiKey to identify to cloud")
+        parser.add_argument('-d', '--screenshot_dir', type=str, required=True, help="Path to screenshot directory")
+        parser.add_argument('-t', '--test', type=str, required=True, choices=self.available_tests, help="The test file to be run")
+        parser.add_argument('-a', '--app', type=str, required=False, help="Name of app uploaded to cloud using upload.py script. Or ""latest"" to reuse last used app. Mandatory for app testing")
+        parser.add_argument('-m', '--device', type=str, required=False, help="Full name of device to use")
+        parser.add_argument('-p', '--project', type=str, required=False, help="The name of the cloud project")
+        parser.add_argument('-r', '--run_name', type=str, required=False, help="The name of the test run")
+        parser.add_argument('-u', '--url', type=str, required=False, help="Testdroid Cloud url where test project and devices are found")
+        parser.add_argument('-i', '--appium_url', type=str, required=False, help="Testdroid Appium url")
+        parser.add_argument('--bundle_id', type=str, required=False, help="Mandatory bundleID when running iOS tests")
+        parser.add_argument('--app_package', type=str, required=False, help="Mandatory app package path for native Android tests")
+        parser.add_argument('--app_activity', type=str, required=False, help="Mandatory main activity for native Android tests")
+        parser.add_argument('--cmd_timeout', type=str, required=False, help="New command timeout value, default is 60s")
+        parser.add_argument('--test_timeout', type=str, required=False, help="Maximum test duration, defaults to 600s")
+
+
+        args = parser.parse_args()
+        # mandatory params
+        self.variables['TESTDROID_APIKEY'] = str(args.apikey)
+        self.variables['TESTDROID_SCREENSHOTS'] = str(args.screenshot_dir)
+        self.selected_test = args.test
+
+        # optional parameters
+        if args.app:
+            self.variables['TESTDROID_APP'] = str(args.app)
+        if args.device:
+            self.variables['TESTDROID_DEVICE'] = str(args.device)            
+            
+        if args.project:
+            self.variables["TESTDROID_PROJECT"] = args.project
+            
+        if args.run_name:
+            self.variables["TESTDROID_TESTRUN"] = args.run_name
+
+        if args.url:
+            self.variables["TESTDROID_URL"] = args.url
+
+        if args.appium_url:
+            self.variables["TESTDROID_APPIUM_URL"] = args.appium_url
+
+        if args.bundle_id:
+            self.variables["TESTDROID_BUNDLE_ID"] = args.bundle_id
+
+        if args.app_package:
+            self.variables["TESTDROID_APP_PACKAGE"] = args.app_package
+
+        if args.app_activity:
+            self.variables["TESTDROID_ACTIVITY"] = args.app_activity
+
+        if args.cmd_timeout:
+            self.variables["TESTDROID_CMD_TIMEOUT"] = args.cmd_timeout
+
+        if args.test_timeout:
+            self.variables["TESTDROID_TEST_TIMEOUT"] = args.test_timeout
+
+
+        # export variables + values
+        for key in self.variables:
+            # print "  {} : {}".format(key, self.variables[key])
+            os.environ[key] = str(self.variables[key])
+
+
+    def print_values(self):
+        print "Stored environment variables:"
+        for key in self.variables.keys():
+            print "  {} : {}".format(key, os.environ.get(key, 'Not set'))
+
+
+    def run_selected_test(self):
+        module = importlib.import_module(self.selected_test)
+
+        test = module.initialize()
+        suite = unittest.TestLoader().loadTestsFromTestCase(test)
+        unittest.TextTestRunner(verbosity=2).run(suite)
+
+
+if __name__ == '__main__':
+    runner = TestdroidTestRunner()
+    runner.parse_args()
+#    runner.print_values()
+    runner.run_selected_test()

--- a/appium/sample-scripts/python/testdroid_android.py
+++ b/appium/sample-scripts/python/testdroid_android.py
@@ -27,7 +27,7 @@ class TestdroidAndroid(unittest.TestCase):
         testdroid_apiKey = os.environ.get('TESTDROID_APIKEY') or ""
         testdroid_app = os.environ.get('TESTDROID_APP') or ""
         appium_url = os.environ.get('TESTDROID_APPIUM_URL') or 'http://appium.testdroid.com/wd/hub'
-        testdroid_project_name = os.environ.get('TESTDROID_PROJECT') or "An Android demo"
+        testdroid_project_name = os.environ.get('TESTDROID_PROJECT') or "Android sample project"
         testdroid_testrun_name = os.environ.get('TESTDROID_TESTRUN') or "My testrun"
         app_package = os.environ.get('TESTDROID_APP_PACKAGE') or 'com.bitbar.testdroid'
         app_activity = os.environ.get('TESTDROID_ACTIVITY') or '.BitbarSampleApplicationActivity'

--- a/appium/sample-scripts/python/testdroid_android.py
+++ b/appium/sample-scripts/python/testdroid_android.py
@@ -1,6 +1,6 @@
 ##
 ## For help on setting up your machine and configuring this TestScript go to
-## http://help.testdroid.com/customer/portal/topics/631129-appium/articles
+## http://docs.testdroid.com/appium/
 ##
 
 import os
@@ -22,11 +22,17 @@ class TestdroidAndroid(unittest.TestCase):
         ## You can set the parameters outside the script with environment variables.
         ## If env var is not set the string after or is used.
         ##
-        self.screenshotDir = os.environ.get('TESTDROID_SCREENSHOTS') or "/absolute/path/to/desired/directory"
+        self.screenshot_dir = os.environ.get('TESTDROID_SCREENSHOTS') or "/absolute/path/to/desired/directory"
         testdroid_url = os.environ.get('TESTDROID_URL') or "https://cloud.testdroid.com"
         testdroid_apiKey = os.environ.get('TESTDROID_APIKEY') or ""
         testdroid_app = os.environ.get('TESTDROID_APP') or ""
         appium_url = os.environ.get('TESTDROID_APPIUM_URL') or 'http://appium.testdroid.com/wd/hub'
+        testdroid_project_name = os.environ.get('TESTDROID_PROJECT') or "An Android demo"
+        testdroid_testrun_name = os.environ.get('TESTDROID_TESTRUN') or "My testrun"
+        app_package = os.environ.get('TESTDROID_APP_PACKAGE') or 'com.bitbar.testdroid'
+        app_activity = os.environ.get('TESTDROID_ACTIVITY') or '.BitbarSampleApplicationActivity'
+        new_command_timeout = os.environ.get('TESTDROID_CMD_TIMEOUT') or '60'
+        testdroid_test_timeout = os.environ.get('TESTDROID_TEST_TIMEOUT') or '600'
 
         # Options to select device
         # 1) Set environment variable TESTDROID_DEVICE
@@ -51,22 +57,22 @@ class TestdroidAndroid(unittest.TestCase):
             desired_capabilities_cloud['testdroid_target'] = 'Android'
         else:
             desired_capabilities_cloud['testdroid_target'] = 'Selendroid'
-        desired_capabilities_cloud['testdroid_project'] = os.environ.get('TESTDROID_PROJECT') or 'Android demo'
-        desired_capabilities_cloud['testdroid_testrun'] = os.environ.get('TESTDROID_TESTRUN') or 'My testrun'
+
+        desired_capabilities_cloud['testdroid_project'] = testdroid_project_name
+        desired_capabilities_cloud['testdroid_testrun'] = testdroid_testrun_name
         desired_capabilities_cloud['testdroid_device'] = testdroid_device
         desired_capabilities_cloud['testdroid_app'] = testdroid_app
-        #desired_capabilities_cloud['app'] = '/absolute/path/to/your/application.apk'
         desired_capabilities_cloud['platformName'] = 'Android'
         desired_capabilities_cloud['deviceName'] = 'Android Phone'
-        desired_capabilities_cloud['appPackage'] = 'com.bitbar.testdroid'
-        desired_capabilities_cloud['appActivity'] = '.BitbarSampleApplicationActivity'
+        desired_capabilities_cloud['appPackage'] = app_package
+        desired_capabilities_cloud['appActivity'] = app_activity
+        desired_capabilities_cloud['newCommandTimeout'] = new_command_timeout
+        desired_capabilities_cloud['testdroid_testTimeout'] = testdroid_test_timeout
 
-        desired_caps = desired_capabilities_cloud;
-
-        log ("Will save screenshots at: " + self.screenshotDir)
+        log ("Will save screenshots at: " + self.screenshot_dir)
         # set up webdriver
         log ("WebDriver request initiated. Waiting for response, this typically takes 2-3 mins")
-        self.driver = webdriver.Remote(appium_url, desired_caps)
+        self.driver = webdriver.Remote(appium_url, desired_capabilities_cloud)
         log ("WebDriver response received")
 
     def tearDown(self):
@@ -83,7 +89,7 @@ class TestdroidAndroid(unittest.TestCase):
                 isSelendroid = True
 
         log ("  Taking screenshot: 1_appLaunch.png")
-        self.driver.save_screenshot(self.screenshotDir + "/1_appLaunch.png")
+        self.driver.save_screenshot(self.screenshot_dir + "/1_appLaunch.png")
 
         log ("  Typing in name")
         elems=self.driver.find_elements_by_class_name('android.widget.EditText')
@@ -92,7 +98,15 @@ class TestdroidAndroid(unittest.TestCase):
         elems[0].send_keys("Testdroid User")
         sleep(2)
         log ("  Taking screenshot: 2_nameTyped.png")
-        self.driver.save_screenshot(self.screenshotDir + "/2_nameTyped.png")
+        self.driver.save_screenshot(self.screenshot_dir + "/2_nameTyped.png")
+
+        log ("  Switching to landscape: 2_landscape.png")
+        self.driver.orientation = "LANDSCAPE"
+        self.driver.save_screenshot(self.screenshot_dir + "/2_landscape.png")
+        log ("  Switching to portrait: 2_portrait.png")
+        self.driver.orientation = "PORTRAIT"
+        self.driver.save_screenshot(self.screenshot_dir + "/2_portrait.png")
+
 
         try:
             log ("  Hiding keyboard")
@@ -100,7 +114,7 @@ class TestdroidAndroid(unittest.TestCase):
         except:
             pass # pass exception, if keyboard isn't visible already
         log ("  Taking screenshot: 3_nameTypedKeyboardHidden.png")
-        self.driver.save_screenshot(self.screenshotDir + "/3_nameTypedKeyboardHidden.png")
+        self.driver.save_screenshot(self.screenshot_dir + "/3_nameTypedKeyboardHidden.png")
 
         log ("  Clicking element 'Buy 101 devices'")
         if isSelendroid:
@@ -110,7 +124,7 @@ class TestdroidAndroid(unittest.TestCase):
         elem.click()
 
         log ("  Taking screenshot: 4_clickedButton1.png")
-        self.driver.save_screenshot(self.screenshotDir + "/4_clickedButton1.png")
+        self.driver.save_screenshot(self.screenshot_dir + "/4_clickedButton1.png")
 
         log ("  Clicking Answer")
         if isSelendroid:
@@ -120,12 +134,12 @@ class TestdroidAndroid(unittest.TestCase):
         elem.click()
 
         log ("  Taking screenshot: 5_answer.png")
-        self.driver.save_screenshot(self.screenshotDir + "/5_answer.png")
+        self.driver.save_screenshot(self.screenshot_dir + "/5_answer.png")
 
         log ("Navigating back to Activity-1")
         self.driver.back()
         log ("  Taking screenshot: 6_mainActivity.png")
-        self.driver.save_screenshot(self.screenshotDir + "/6_mainActivity.png")
+        self.driver.save_screenshot(self.screenshot_dir + "/6_mainActivity.png")
 
         log ("  Clicking element 'Use Testdroid Cloud'")
         if isSelendroid:
@@ -135,7 +149,7 @@ class TestdroidAndroid(unittest.TestCase):
         elem.click()
 
         log ("  Taking screenshot: 7_clickedButton2.png")
-        self.driver.save_screenshot(self.screenshotDir + "/7_clickedButton2.png")
+        self.driver.save_screenshot(self.screenshot_dir + "/7_clickedButton2.png")
 
         log ("  Clicking Answer")
         if isSelendroid:
@@ -145,7 +159,10 @@ class TestdroidAndroid(unittest.TestCase):
         elem.click()
 
         log ("  Taking screenshot: 8_answer.png")
-        self.driver.save_screenshot(self.screenshotDir + "/8_answer.png")
+        self.driver.save_screenshot(self.screenshot_dir + "/8_answer.png")
+
+def initialize():
+    return TestdroidAndroid
 
 if __name__ == "__main__":
     suite = unittest.TestLoader().loadTestsFromTestCase(TestdroidAndroid)

--- a/appium/sample-scripts/python/testdroid_android_hybrid.py
+++ b/appium/sample-scripts/python/testdroid_android_hybrid.py
@@ -37,7 +37,7 @@ class TestdroidAndroid(unittest.TestCase):
         appium_url = os.environ.get('TESTDROID_APPIUM_URL') or 'http://appium.testdroid.com/wd/hub'
         app_package = os.environ.get('TESTDROID_APP_PACKAGE') or 'com.testdroid.sample.android'
         app_activity = os.environ.get('TESTDROID_ACTIVITY') or '.MA_MainActivity'
-        testdroid_project = os.environ.get('TESTDROID_PROJECT') or 'Android Hybrid Demo'
+        testdroid_project = os.environ.get('TESTDROID_PROJECT') or 'Android hybrid sample project'
         testdroid_testrun = os.environ.get('TESTDROID_TESTRUN') or 'My testrun'
         new_command_timeout = os.environ.get('TESTDROID_CMD_TIMEOUT') or '60'
         testdroid_test_timeout = os.environ.get('TESTDROID_TEST_TIMEOUT') or '600'
@@ -95,6 +95,7 @@ class TestdroidAndroid(unittest.TestCase):
         print self.driver.get_window_size()
 
         self.screenshot("appLaunch")
+        sleep(3)
 
         log('clicking button "hybrid app"')
         element=self.driver.find_element_by_id('com.testdroid.sample.android:id/mm_b_hybrid')

--- a/appium/sample-scripts/python/testdroid_android_hybrid.py
+++ b/appium/sample-scripts/python/testdroid_android_hybrid.py
@@ -59,10 +59,17 @@ class TestdroidAndroid(unittest.TestCase):
             while testdroid_device == "":
                 testdroid_device = deviceFinder.available_free_android_device()
 
+        apiLevel = deviceFinder.device_API_level(testdroid_device)
+        print "Starting Appium test using device '%s'" % testdroid_device
 
         desired_capabilities_cloud = {}
         desired_capabilities_cloud['testdroid_apiKey'] = testdroid_apiKey
-        desired_capabilities_cloud['testdroid_target'] = 'selendroid'
+        if apiLevel > 16:
+            desired_capabilities_cloud['testdroid_target'] = 'android'
+        else:
+            desired_capabilities_cloud['testdroid_target'] = 'selendroid'
+
+        desired_capabilities_cloud['testdroid_apiKey'] = testdroid_apiKey
         desired_capabilities_cloud['testdroid_project'] = testdroid_project
         desired_capabilities_cloud['testdroid_testrun'] = testdroid_testrun
         desired_capabilities_cloud['testdroid_device'] = testdroid_device

--- a/appium/sample-scripts/python/testdroid_android_hybrid.py
+++ b/appium/sample-scripts/python/testdroid_android_hybrid.py
@@ -1,6 +1,6 @@
 ##
 ## For help on setting up your machine and configuring this TestScript go to
-## http://help.testdroid.com/customer/portal/topics/631129-appium/articles
+## http://docs.testdroid.com/appium/
 ##
 
 import os
@@ -16,12 +16,11 @@ def log(msg):
 class TestdroidAndroid(unittest.TestCase):
 
     def screenshot(self, name):
-        self.screenShotCount = 1
-        screenshotName = str(self.screenShotCount) + "_" + name + ".png" 
+        screenshotName = str(self.screenshot_count) + "_" + name + ".png" 
         log ("Taking screenshot: " + screenshotName)
         sleep(1) # wait for animations to complete before taking screenshot
-        driver.save_screenshot(self.screenshotDir + "/" + screenshotName)
-        self.screenShotCount += 1
+        self.driver.save_screenshot(self.screenshot_dir + "/" + screenshotName)
+        self.screenshot_count += 1
 
     
     def setUp(self):
@@ -31,17 +30,26 @@ class TestdroidAndroid(unittest.TestCase):
         ## You can set the parameters outside the script with environment variables.
         ## If env var is not set the string after or is used.
         ##
-        self.screenshotDir = os.environ.get('TESTDROID_SCREENSHOTS') or "/absolute/path/to/desired/directory"
+        self.screenshot_dir = os.environ.get('TESTDROID_SCREENSHOTS') or "/absolute/path/to/desired/directory"
         testdroid_url = os.environ.get('TESTDROID_URL') or "https://cloud.testdroid.com"
         testdroid_apiKey = os.environ.get('TESTDROID_APIKEY') or ""
         testdroid_app = os.environ.get('TESTDROID_APP') or ""
         appium_url = os.environ.get('TESTDROID_APPIUM_URL') or 'http://appium.testdroid.com/wd/hub'
+        app_package = os.environ.get('TESTDROID_APP_PACKAGE') or 'com.testdroid.sample.android'
+        app_activity = os.environ.get('TESTDROID_ACTIVITY') or '.MA_MainActivity'
+        testdroid_project = os.environ.get('TESTDROID_PROJECT') or 'Android Hybrid Demo'
+        testdroid_testrun = os.environ.get('TESTDROID_TESTRUN') or 'My testrun'
+        new_command_timeout = os.environ.get('TESTDROID_CMD_TIMEOUT') or '60'
+        testdroid_test_timeout = os.environ.get('TESTDROID_TEST_TIMEOUT') or '600'
+
+        log ("Will save screenshots at: " + self.screenshot_dir)
+        self.screenshot_count = 1
+
 
         # Options to select device
         # 1) Set environment variable TESTDROID_DEVICE
         # 2) Set device name to this python script
         # 3) Do not set #1 and #2 and let DeviceFinder to find free device for you
-
         deviceFinder = None
         testdroid_device = os.environ.get('TESTDROID_DEVICE') or ""
 
@@ -51,29 +59,25 @@ class TestdroidAndroid(unittest.TestCase):
             while testdroid_device == "":
                 testdroid_device = deviceFinder.available_free_android_device()
 
-        
+
         desired_capabilities_cloud = {}
         desired_capabilities_cloud['testdroid_apiKey'] = testdroid_apiKey
-        desired_capabilities_cloud['testdroid_target'] = 'chrome'
-        desired_capabilities_cloud['testdroid_project'] = 'Appium Android Hybrid Demo'
-        desired_capabilities_cloud['testdroid_testrun'] = 'TestRun 1'
+        desired_capabilities_cloud['testdroid_target'] = 'selendroid'
+        desired_capabilities_cloud['testdroid_project'] = testdroid_project
+        desired_capabilities_cloud['testdroid_testrun'] = testdroid_testrun
         desired_capabilities_cloud['testdroid_device'] = testdroid_device
         desired_capabilities_cloud['testdroid_app'] = testdroid_app
         desired_capabilities_cloud['platformName'] = 'Android'
         desired_capabilities_cloud['deviceName'] = 'Android Phone'
         desired_capabilities_cloud['automationName'] = 'selendroid'
-        desired_capabilities_cloud['appPackage'] = 'com.testdroid.sample.android'
-        desired_capabilities_cloud['appActivity'] = '.MA_MainActivity'
-
-        desired_caps = desired_capabilities_cloud;
-
-        log ("Will save screenshots at: " + self.screenshotDir)
+        desired_capabilities_cloud['newCommandTimeout'] = new_command_timeout
+        desired_capabilities_cloud['testdroid_testTimeout'] = testdroid_test_timeout
 
         # set up webdriver
         log ("WebDriver request initiated. Waiting for response, this typically takes 2-3 mins")
-        self.driver = webdriver.Remote(appium_url, desired_caps)
+        self.driver = webdriver.Remote(appium_url, desired_capabilities_cloud)
         log ("WebDriver response received")
-        
+
     def tearDown(self):
         log ("Quitting")
         self.driver.quit()
@@ -146,6 +150,8 @@ class TestdroidAndroid(unittest.TestCase):
         self.driver.back()
         self.screenshot('launchScreen')
 
+def initialize():
+    return TestdroidAndroid
 
 if __name__ == "__main__":
     suite = unittest.TestLoader().loadTestsFromTestCase(TestdroidAndroid)

--- a/appium/sample-scripts/python/testdroid_ios.py
+++ b/appium/sample-scripts/python/testdroid_ios.py
@@ -1,6 +1,6 @@
 ##
 ## For help on setting up your machine and configuring this TestScript go to
-## http://help.testdroid.com/customer/portal/topics/631129-appium/articles
+## http://docs.testdroid.com/appium/
 ##
 
 import os
@@ -27,6 +27,9 @@ class TestdroidIOS(unittest.TestCase):
         self.screenshot_dir = os.environ.get('TESTDROID_SCREENSHOTS') or "/absolute/path/to/desired/directory"
         testdroid_project_name = os.environ.get('TESTDROID_PROJECT') or "Appium iOS demo"
         testdroid_testrun_name = os.environ.get('TESTDROID_TESTRUN') or "My testrun"
+        testdroid_bundle_id = os.environ.get('TESTDROID_BUNDLE_ID') or "com.bitbar.testdroid.BitbarIOSSample"
+        new_command_timeout = os.environ.get('TESTDROID_CMD_TIMEOUT') or '60'
+        testdroid_test_timeout = os.environ.get('TESTDROID_TEST_TIMEOUT') or '600'
 
         # Options to select device
         # 1) Set environment variable TESTDROID_DEVICE
@@ -44,18 +47,19 @@ class TestdroidIOS(unittest.TestCase):
 
         print "Starting Appium test using device '%s'" % testdroid_device
 
-        desired_capabilities_cloud={
-                'testdroid_apiKey': testdroid_apiKey,
-                'testdroid_target': 'ios',
-                'testdroid_project': testdroid_project_name,
-                'testdroid_testrun': testdroid_testrun_name,
-                'testdroid_device': testdroid_device,
-                'testdroid_app': testdroid_app,
-                'testdroid_description': 'Appium project description',
-                'platformName': 'iOS',
-                'deviceName': 'iPhone device',
-                'bundleId': 'com.bitbar.testdroid.BitbarIOSSample',
-        }
+        desired_capabilities_cloud = {}
+        desired_capabilities_cloud['testdroid_apiKey'] = testdroid_apiKey
+        desired_capabilities_cloud['testdroid_target'] = 'ios'
+        desired_capabilities_cloud['testdroid_project'] = testdroid_project_name
+        desired_capabilities_cloud['testdroid_testrun'] = testdroid_testrun_name
+        desired_capabilities_cloud['testdroid_device'] = testdroid_device
+        desired_capabilities_cloud['testdroid_app'] = testdroid_app
+        desired_capabilities_cloud['testdroid_description'] = 'Appium iOS project description'
+        desired_capabilities_cloud['platformName'] = 'iOS'
+        desired_capabilities_cloud['deviceName'] = 'iPhone device'
+        desired_capabilities_cloud['bundleId'] = testdroid_bundle_id
+        desired_capabilities_cloud['newCommandTimeout'] = new_command_timeout
+        desired_capabilities_cloud['testdroid_testTimeout'] = testdroid_test_timeout
 
         # set up webdriver
         log ("WebDriver request initiated. Waiting for response, this typically takes 2-3 mins")
@@ -119,6 +123,11 @@ class TestdroidIOS(unittest.TestCase):
 
         log ("view1: Sleeping 3 before quitting webdriver.")
         sleep(3)
+
+
+def initialize():
+    return TestdroidIOS
+
 
 if __name__ == "__main__":
     suite = unittest.TestLoader().loadTestsFromTestCase(TestdroidIOS)

--- a/appium/sample-scripts/python/testdroid_ios.py
+++ b/appium/sample-scripts/python/testdroid_ios.py
@@ -54,7 +54,6 @@ class TestdroidIOS(unittest.TestCase):
         desired_capabilities_cloud['testdroid_testrun'] = testdroid_testrun_name
         desired_capabilities_cloud['testdroid_device'] = testdroid_device
         desired_capabilities_cloud['testdroid_app'] = testdroid_app
-        desired_capabilities_cloud['testdroid_description'] = 'Appium iOS project description'
         desired_capabilities_cloud['platformName'] = 'iOS'
         desired_capabilities_cloud['deviceName'] = 'iPhone device'
         desired_capabilities_cloud['bundleId'] = testdroid_bundle_id

--- a/appium/sample-scripts/python/testdroid_ios.py
+++ b/appium/sample-scripts/python/testdroid_ios.py
@@ -25,7 +25,7 @@ class TestdroidIOS(unittest.TestCase):
         testdroid_apiKey = os.environ.get('TESTDROID_APIKEY') or ""
         testdroid_app = os.environ.get('TESTDROID_APP') or ""
         self.screenshot_dir = os.environ.get('TESTDROID_SCREENSHOTS') or "/absolute/path/to/desired/directory"
-        testdroid_project_name = os.environ.get('TESTDROID_PROJECT') or "Appium iOS demo"
+        testdroid_project_name = os.environ.get('TESTDROID_PROJECT') or "iOS sample project"
         testdroid_testrun_name = os.environ.get('TESTDROID_TESTRUN') or "My testrun"
         testdroid_bundle_id = os.environ.get('TESTDROID_BUNDLE_ID') or "com.bitbar.testdroid.BitbarIOSSample"
         new_command_timeout = os.environ.get('TESTDROID_CMD_TIMEOUT') or '60'


### PR DESCRIPTION
* sample tests unified
* runt-test.py to launch samples 
* all sample environment variables can be set through run-test.py
* web samples have new wait_until_xpath_matches method that tries to find xpath for given period
* samples now use the sample class' screenshot method
