### PR TITLE
Removed line proc.waitFor();, it resulted sometimes in adb device size failure

### DIFF
--- a/image-recognition/src/main/java/TestdroidImageRecognition.java
+++ b/image-recognition/src/main/java/TestdroidImageRecognition.java
@@ -830,7 +830,6 @@ public class TestdroidImageRecognition extends AbstractAppiumTest {
                 while ((line = br.readLine()) != null) {
                     if (!line.contains("OriginalmUnrestrictedScreen")) { //we do this check for devices with android 5.x+ The adb command returns an extra line with the values 0x0 which must be filtered out.
                         if (line.contains("mUnrestrictedScreen")) {
-                            proc.waitFor();
                             String[] tmp = line.split("\\) ");
                             size = tmp[1].split("x");
                         }


### PR DESCRIPTION
Removed line proc.waitFor();, it resulted sometimes in adb not getting the device size and failing.